### PR TITLE
修复方法级别中间件不起作用的BUG

### DIFF
--- a/src/DispatcherFactory.php
+++ b/src/DispatcherFactory.php
@@ -36,11 +36,11 @@ class DispatcherFactory extends Dispatcher
         foreach ($methods as $methodName => $method) {
             $methodMiddlewares = $middlewares;
             // Handle method level middlewares.
+            $methodName = $method->getName();
             if (isset($methodMetadata[$methodName])) {
                 $methodMiddlewares = array_merge($methodMiddlewares, $this->handleMiddleware($methodMetadata[$methodName]));
                 $methodMiddlewares = array_unique($methodMiddlewares);
             }
-            $methodName = $method->getName();
             if (substr($methodName, 0, 2) === '__') {
                 continue;
             }


### PR DESCRIPTION
1.修复方法级别中间件不起作用的BUG
2.原因是 $methodName 为索引，需要把  $methodName = $method->getName(); 放到最前面